### PR TITLE
Add of repo for PHP 5.5, mongodb automated, apache IP typo.

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -6,6 +6,7 @@ sudo apt-get update
 # For PHP 5.5
 #
 sudo apt-get install -y python-software-properties
+sudo add-apt-repository ppa:ondrej/php5
 sudo apt-get update
 
 #
@@ -27,7 +28,7 @@ sudo apt-get install -y redis-server
 #
 # MongoDB
 #
-sudo apt-get install mongodb-clients mongodb-server
+sudo apt-get install -y mongodb-clients mongodb-server
 
 #
 # Utilities
@@ -135,5 +136,5 @@ echo -e
 echo -e "Then follow the README.md to copy/paste the VirtualHost!\n"
 
 echo -e "----------------------------------------"
-echo -e "Default Site: http://192.168.5.0"
+echo -e "Default Site: http://192.168.50.4"
 echo -e "----------------------------------------"


### PR DESCRIPTION
Provisioning process was failing due to:
- PHP were supposed to be 5.5, but `precise` uses 5.3 by default
- Miss `-y` parameter for MongoDB

Improvements:
1. Proposing usage of: https://launchpad.net/~ondrej/+archive/ubuntu/php5
2. Add of `-y` option in `apt` for MongoDB
3. Fix of a typo about the IP address