### PR TITLE
Include 'php5.6-mongo' package

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -98,6 +98,7 @@ apt-get install -y php5.6 \
   php5.6-mcrypt \
   php5.6-memcached \
   php5.6-memcache \
+  php5.6-mongo \
   php5.6-mongodb \
   php5.6-mysqli \
   php5.6-pgsql \


### PR DESCRIPTION
Included 'php5.6-mongo' as the already included 'php5.6-mongodb' isn't supported by Phalcon.