### PR TITLE
Update init.sh - Fixes phalcon-dev-tools

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -216,7 +216,8 @@ rm -rf ~/vendor
 echo "export PTOOLSPATH=/opt/phalcon-tools/" >> /home/vagrant/.bashrc
 echo "export PATH=\$PATH:/opt/phalcon-tools/" >> /home/vagrant/.bashrc
 chmod +x /opt/phalcon-tools/phalcon.sh
-ln -s /opt/phalcon-tools/phalcon.sh /usr/bin/phalcon
+ln -s /opt/phalcon-tools/phalcon.php /usr/bin/phalcon
+chmod ugo+x /usr/bin/phalcon
 
 #
 # Tune UP PHP


### PR DESCRIPTION
This init.sh version fixes a issue that did not allow the vagrant box to allow usage of "phalcon commands".
The phalcon-dev-tools were linked to the .sh file instead of the required .php file.